### PR TITLE
#45 new page StatValueCreate as modal

### DIFF
--- a/RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor
+++ b/RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor
@@ -69,7 +69,12 @@ else
         </MudItem>
         <MudItem xs="12">
             <MudPaper Class="pa-4 border border-dark" Outlined="true" Elevation="10">
-                <MudText Typo="Typo.h5" class="mb-4" Align="Align.Center">Statuswerte</MudText>
+                <div style="display: flex; align-items: center;">
+                    <MudText Typo="Typo.h5" class="mb-4" Align="Align.Center" style="flex-grow: 1; text-align: center;">Statuswerte</MudText>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" OnClick="AddNewStat" style="margin-left: auto;">
+                        Neu
+                    </MudButton>
+                </div>
                 <MudTable Items="@GetStatValuesByLevel()" Dense="true" Hover="true" Breakpoint="Breakpoint.None" FixedHeader="true">
                     <HeaderContent>
                         <MudTh><strong>Level</strong></MudTh>
@@ -91,7 +96,7 @@ else
                                     var statValue = context.Value.FirstOrDefault(sv => sv.StatId == stat.Id);
                                     if (statValue != null)
                                     {
-                                        <MudTooltip Text="@($"Basis: {statValue.Value}{Environment.NewLine}Bonus: +{statValue.ContainedBonusNum} / +{statValue.ContainedBonusNum}%")">
+                                        <MudTooltip Text="@($"Basis: {statValue.Value}{Environment.NewLine}Bonus: +{statValue.ContainedBonusNum} / +{statValue.ContainedBonusPercent}%")">
                                             <MudText>@statValue.Value</MudText>
                                         </MudTooltip>
                                     }
@@ -189,4 +194,11 @@ else
             .ToDictionary(g => g.Key, g => g.ToList());
     }
 
+    private void AddNewStat()
+    {
+        var dialogOptions = new DialogOptions { CloseOnEscapeKey = true };
+        var dialogParameter = new DialogParameters { { "Character", _character }, { "Stats", _stats } };
+        var dialog = DialogService.Show<StatValueCreate>("Neuer Statuswert", dialogParameter, dialogOptions);
+        var result = dialog.Result;
+    }
 }

--- a/RpgStats.BlazorServer/Shared/StatValueCreate.razor
+++ b/RpgStats.BlazorServer/Shared/StatValueCreate.razor
@@ -1,0 +1,99 @@
+@using RpgStats.BlazorServer.Model
+@using RpgStats.Dto
+@inject IHttpClientFactory HttpClientFactory
+@inject IDialogService DialogService
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField Label="Level" @bind-Value="Level" Numeric="true" />
+        <MudDivider />
+        @if (Stats != null)
+        {
+            foreach (var statDto in Stats.OrderBy(x => x.ShortName).ToList())
+            {
+                var statValueDto = _statValues.FirstOrDefault(sv => sv.StatId == statDto.Id);
+                if (statValueDto == null)
+                {
+                    statValueDto = new StatValueDto() { StatId = statDto.Id, CharacterId = Character?.Id ?? 0, Level = Level };
+                    _statValues.Add(statValueDto);
+                }
+                <MudItem>
+                    <MudGrid>
+                        <MudItem xs="6">
+                            <MudTextField Label="@statDto.ShortName" @bind-Value="statValueDto.Value" Numeric="true"/>
+                        </MudItem>
+                        <MudItem xs="3">
+                            <MudTextField Label="+BonusNum" @bind-Value="statValueDto.ContainedBonusNum" Numeric="true"/>
+                        </MudItem>
+                        <MudItem xs="3">
+                            <MudTextField Label="+BonusPercent" @bind-Value="statValueDto.ContainedBonusPercent" Numeric="true"/>
+                        </MudItem>
+                    </MudGrid>
+                </MudItem>
+            }
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Abbrechen</MudButton>
+        <MudButton OnClick="Submit" Color="Color.Primary">Speichern</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance? MudDialog { get; set; }
+
+    [Parameter] public List<StatDto>? Stats { get; set; }
+    [Parameter] public CharacterDetailDto? Character { get; set; }
+
+    private HttpClient HttpClient => HttpClientFactory.CreateClient("RpgStatsApi");
+    private readonly List<StatValueDto> _statValues = new();
+    private int Level { get; set; }
+
+    protected override void OnInitialized()
+    {
+        if (Stats != null)
+        {
+            foreach (var statDto in Stats.OrderBy(x => x.ShortName).ToList())
+            {
+                var statValueDto = new StatValueDto() { StatId = statDto.Id, CharacterId = Character?.Id ?? 0, Level = Level };
+                _statValues.Add(statValueDto);
+            }
+        }
+    }
+
+    private void Cancel()
+    {
+        MudDialog?.Cancel();
+    }
+
+    private async Task Submit()
+    {
+        foreach (var statValueDto in _statValues)
+        {
+            var svCreationDto = new StatValueForCreationDto()
+            {
+                Level = Level,
+                Value = statValueDto.Value,
+                ContainedBonusNum = statValueDto.ContainedBonusNum,
+                ContainedBonusPercent = statValueDto.ContainedBonusPercent
+            };
+
+            var response = await HttpClient.PostAsJsonAsync($"api/StatValue/CreateStatValue/{Character?.Id}/{statValueDto.StatId}", svCreationDto);
+            var responseContent = await response.Content.ReadFromJsonAsync<RpgStatsResponse<StatValueDto>>();
+
+            if (response.IsSuccessStatusCode) return;
+            await ShowErrorMessage("Fehler beim Speichern der Werte.");
+
+            if (responseContent?.Success != false) continue;
+            await ShowErrorMessage(responseContent.ErrorMessage);
+
+            return;
+        }
+        MudDialog?.Close();
+    }
+
+    private async Task ShowErrorMessage(string text)
+    {
+        await DialogService.ShowMessageBox("Error", text);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the character detail page in the `RpgStats.BlazorServer` project. The key changes include adding a new button to create a status value, updating tooltip text, and implementing a new dialog component for creating status values.

Enhancements to character detail page:

* [`RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor`](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L72-R77): Added a "Neu" button next to the "Statuswerte" text to allow users to add new status values.
* [`RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor`](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L94-R99): Updated tooltip text to display the correct bonus percentage.
* [`RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor`](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04R197-R203): Implemented the `AddNewStat` method to open a dialog for creating new status values.

New dialog component:

* [`RpgStats.BlazorServer/Shared/StatValueCreate.razor`](diffhunk://#diff-338bff5397dbd191adc661eab62ecdc3c84daafcba1eb7b5d7a232153b6c3e7cR1-R99): Created a new dialog component for adding status values, including fields for level, bonus numbers, and bonus percentages.