### PR TITLE
#52 show custom statnames in ui

### DIFF
--- a/RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor
+++ b/RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor
@@ -78,34 +78,40 @@ else
                 <MudTable Items="@GetStatValuesByLevel()" Dense="true" Hover="true" Breakpoint="Breakpoint.None" FixedHeader="true">
                     <HeaderContent>
                         <MudTh><strong>Level</strong></MudTh>
-                        @foreach (var stat in _stats)
+                        @if (_gameStats != null)
                         {
-                            <MudTh>
-                                <MudTooltip Text="@stat.Name">
-                                    <strong>@stat.ShortName</strong>
-                                </MudTooltip>
-                            </MudTh>
+                            @foreach (var gameStat in _gameStats)
+                            {
+                                <MudTh>
+                                    <MudTooltip Text="@gameStat.CustomStatName">
+                                        <strong>@gameStat.CustomStatShortName</strong>
+                                    </MudTooltip>
+                                </MudTh>
+                            }
                         }
                     </HeaderContent>
                     <RowTemplate>
                         <MudTd>@context.Key</MudTd>
-                        @foreach (var stat in _stats)
+                        @if (_gameStats != null)
                         {
-                            <MudTd>
-                                @{
-                                    var statValue = context.Value.FirstOrDefault(sv => sv.StatId == stat.Id);
-                                    if (statValue != null)
-                                    {
-                                        <MudTooltip Text="@($"Basis: {statValue.Value}{Environment.NewLine}Bonus: +{statValue.ContainedBonusNum} / +{statValue.ContainedBonusPercent}%")">
-                                            <MudText>@statValue.Value</MudText>
-                                        </MudTooltip>
+                            @foreach (var gameStat in _gameStats)
+                            {
+                                <MudTd>
+                                    @{
+                                        var statValue = context.Value.FirstOrDefault(sv => sv.StatId == gameStat.StatId);
+                                        if (statValue != null)
+                                        {
+                                            <MudTooltip Text="@($"Basis: {statValue.Value}{Environment.NewLine}Bonus: +{statValue.ContainedBonusNum} / +{statValue.ContainedBonusPercent}%")">
+                                                <MudText>@statValue.Value</MudText>
+                                            </MudTooltip>
+                                        }
+                                        else
+                                        {
+                                            <MudText>-</MudText>
+                                        }
                                     }
-                                    else
-                                    {
-                                        <MudText>-</MudText>
-                                    }
-                                }
-                            </MudTd>
+                                </MudTd>
+                            }
                         }
                     </RowTemplate>
                 </MudTable>
@@ -118,7 +124,7 @@ else
     private HttpClient HttpClient => HttpClientFactory.CreateClient("RpgStatsApi");
     private CharacterDetailDto? _character;
     private List<StatValueDto>? _statValues = new();
-    private readonly List<StatDto> _stats = new();
+    private List<GameStatDto>? _gameStats = new();
 
     [Parameter] public int Id { get; set; }
 
@@ -126,7 +132,7 @@ else
     {
         await GetCharacter();
         await GetStatValues();
-        await GetStats();
+        await GetGameStats();
     }
 
     private async Task GetStatValues()
@@ -138,20 +144,10 @@ else
         }
     }
 
-    private async Task GetStats()
+    private async Task GetGameStats()
     {
         var response = await HttpClient.GetFromJsonAsync<RpgStatsResponse<List<GameStatDto>>>(($"api/GameStat/GetGameStatsByGame/{_character?.GameWithoutFkObjectsDto?.Id}"));
-        var gameStats = response?.Data?.OrderBy(x => x.SortIndex).ToList();
-
-        if (gameStats == null)
-            return;
-
-        foreach (var gameStat in gameStats)
-        {
-            var stat = await HttpClient.GetFromJsonAsync<RpgStatsResponse<StatDto>>($"api/Stat/GetStatById/{gameStat.StatId}");
-            if (stat != null && stat.Data != null)
-                _stats.Add(stat.Data);
-        }
+        _gameStats = response?.Data?.OrderBy(x => x.SortIndex).ToList();
     }
 
     private async Task GetCharacter()
@@ -207,8 +203,19 @@ else
     private void AddNewStat()
     {
         var dialogOptions = new DialogOptions { CloseOnEscapeKey = true };
-        var dialogParameter = new DialogParameters { { "Character", _character }, { "Stats", _stats } };
-        var dialog = DialogService.Show<StatValueCreate>("Neuer Statuswert", dialogParameter, dialogOptions);
-        var result = dialog.Result;
+        var dialogParameter = new DialogParameters { { "Character", _character }, { "Stats", GetStats() } };
+        DialogService.Show<StatValueCreate>("Neuer Statuswert", dialogParameter, dialogOptions);
+    }
+
+    private List<StatDto> GetStats()
+    {
+        if (_gameStats == null) return new List<StatDto>();
+
+        return _gameStats.Select(gs => new StatDto
+        {
+            Id = gs.StatId,
+            Name = gs.CustomStatName,
+            ShortName = gs.CustomStatShortName
+        }).ToList();
     }
 }

--- a/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
+++ b/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
@@ -79,12 +79,15 @@ else
                         </MudText>
                     </MudTooltip>
                     <MudGrid Class="my-4">
-                        @foreach (var stat in _stats)
+                        @if (_gameStats != null)
                         {
-                            <MudTooltip Class="mt-4" Duration="250" Delay="1000" Placement="Placement.Top"
-                                    Text="@stat.Name">
-                                <MudChip Class="mx-9" Color="Color.Secondary">@stat.ShortName</MudChip>
-                            </MudTooltip>
+                            @foreach (var gameStat in _gameStats)
+                            {
+                                <MudTooltip Class="mt-4" Duration="250" Delay="1000" Placement="Placement.Top"
+                                            Text="@gameStat.CustomStatName">
+                                    <MudChip Class="mx-9" Color="Color.Secondary">@gameStat.CustomStatShortName</MudChip>
+                                </MudTooltip>
+                            }
                         }
                     </MudGrid>
                 }
@@ -111,14 +114,14 @@ else
 @code {
     private HttpClient HttpClient => HttpClientFactory.CreateClient("RpgStatsApi");
     private GameDetailDto? _game;
-    private readonly List<StatDto> _stats = new();
+    private List<GameStatDto>? _gameStats = new();
 
     [Parameter] public int Id { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         await GetGame();
-        await GetStatsInCorrectOrder();
+        await GetGameStats();
     }
 
     private async Task GetGame()
@@ -164,7 +167,7 @@ else
         }
     }
 
-    private async Task GetStatsInCorrectOrder()
+    private async Task GetGameStats()
     {
         var response = await HttpClient.GetAsync($"api/GameStat/GetGameStatsByGame/{_game?.Id}");
 
@@ -173,18 +176,7 @@ else
 
         var rpgStatsResponse = await response.Content.ReadFromJsonAsync<RpgStatsResponse<List<GameStatDto>>>();
 
-        var gameStats = rpgStatsResponse?.Data?.OrderBy(x => x.SortIndex).ToList();
-
-        if (gameStats == null)
-            return;
-
-        _stats.Clear();
-        foreach (var gameStat in gameStats)
-        {
-            var stat = await HttpClient.GetFromJsonAsync<RpgStatsResponse<StatDto>>($"api/Stat/GetStatById/{gameStat.StatId}");
-            if (stat != null && stat.Data != null)
-                _stats.Add(stat.Data);
-        }
+        _gameStats = rpgStatsResponse?.Data?.OrderBy(x => x.SortIndex).ToList();
     }
 
     private async Task LinkGameStat()
@@ -196,7 +188,7 @@ else
         var result = await dialog.Result;
         if (result.Canceled == false)
         {
-            await GetStatsInCorrectOrder();
+            await GetGameStats();
         }
     }
 

--- a/RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor
+++ b/RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor
@@ -20,6 +20,8 @@
         </MudSelect>
         <MudItem xs="6">
             <MudTextField Label="Sortier-Index" @bind-Value="_gameStatDto.SortIndex" Numeric="true"/>
+            <MudTextField Label="Status-Name im Spiel" @bind-Value="_gameStatDto.CustomStatName"/>
+            <MudTextField Label="Status-Kurzname im Spiel" @bind-Value="_gameStatDto.CustomStatShortName" />
         </MudItem>
     </DialogContent>
     <DialogActions>
@@ -78,7 +80,7 @@
         }
         else
         {
-            var response = await HttpClient.PostAsJsonAsync($"api/GameStat/CreateGameStat/{_gameStatDto.GameId}/{_gameStatDto.StatId}/{_gameStatDto.SortIndex}", "");
+            var response = await HttpClient.PostAsJsonAsync($"api/GameStat/CreateGameStat/", _gameStatDto);
             var content = await response.Content.ReadFromJsonAsync<RpgStatsResponse<GameStatDto>>();
             if (!response.IsSuccessStatusCode || content?.Success == false)
             {


### PR DESCRIPTION
The custom names of the stats per game are now visible in the ui. This was forgotten to implement by the developer in the issue #52 

Refactoring to use `GameStatDto`:

* [`RpgStats.BlazorServer/Pages/Characters/CharacterDetail.razor`](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L81-R101): Replaced `_stats` with `_gameStats` and updated the methods and UI elements to use `GameStatDto` instead of `StatDto`. [[1]](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L81-R101) [[2]](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04R115) [[3]](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L121-R135) [[4]](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L141-R150) [[5]](diffhunk://#diff-9edbdb2ea49c5fcd9a073fe4462d43491c65a971c36f224fc695c6185135fa04L210-R219)
* [`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL82-R91): Replaced `_stats` with `_gameStats` and updated the methods and UI elements to use `GameStatDto` instead of `StatDto`. [[1]](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL82-R91) [[2]](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL114-R124) [[3]](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL167-R170) [[4]](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL176-R179) [[5]](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL199-R191)

UI enhancements:

* [`RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor`](diffhunk://#diff-92b21c14029a498417c943dc69e565683cfd7643741ae6cb9e6fee741cb764e4R23-R24): Added new fields for `CustomStatName` and `CustomStatShortName` in the dialog for linking game stats. [[1]](diffhunk://#diff-92b21c14029a498417c943dc69e565683cfd7643741ae6cb9e6fee741cb764e4R23-R24) [[2]](diffhunk://#diff-92b21c14029a498417c943dc69e565683cfd7643741ae6cb9e6fee741cb764e4L81-R83)