### PR TITLE
#53 gamestats are removable

### DIFF
--- a/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
+++ b/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
@@ -85,7 +85,7 @@ else
                             {
                                 <MudTooltip Class="mt-4" Duration="250" Delay="1000" Placement="Placement.Top"
                                             Text="@gameStat.CustomStatName">
-                                    <MudChip Class="mx-9" Color="Color.Secondary">@gameStat.CustomStatShortName</MudChip>
+                                    <MudChip Class="mx-9" Color="Color.Secondary" OnClose="RemoveMudChip" Text="@gameStat.CustomStatShortName"/>
                                 </MudTooltip>
                             }
                         }
@@ -162,6 +162,7 @@ else
                 await ShowErrorMessage(content?.ErrorMessage ?? "Fehler beim Löschen des Spiels.");
                 return;
             }
+
             NavigationManager.NavigateTo("/allGames");
 
         }
@@ -195,5 +196,57 @@ else
     private async Task ShowErrorMessage(string text)
     {
         await DialogService.ShowMessageBox("Error", text);
+    }
+
+    private async Task RemoveMudChip(MudChip chip)
+    {
+        var gameStat = _gameStats?.FirstOrDefault(x => x.CustomStatShortName == chip.Text);
+
+        if (gameStat == null)
+        {
+            await ShowErrorMessage($"GameStat nicht gefunden. {chip.Text}");
+            return;
+        }
+
+        var response = await HttpClient.GetAsync($"api/StatValue/GetStatValuesByStat/{gameStat.StatId}");
+        var statValues = await response.Content.ReadFromJsonAsync<RpgStatsResponse<List<StatValueDto>>>();
+
+        if (statValues?.Data == null)
+        {
+            await RemoveGameStat(gameStat);
+            return;
+        }
+
+        if (_game == null || _game.CharacterWithoutFkObjectsDtos == null)
+            return;
+
+        var anyCharacterHasStatValue = false;
+        foreach (var character in _game.CharacterWithoutFkObjectsDtos)
+        {
+            anyCharacterHasStatValue = statValues.Data.Any(x => x.CharacterId == character.Id);
+            if (anyCharacterHasStatValue)
+                break;
+        }
+
+        if (anyCharacterHasStatValue)
+        {
+            await ShowErrorMessage("Es gibt noch Charaktere, die noch Statuswerte mit diesem Status haben. Bitte lösche zuerst die Einträge bevor die Zuordnung entfernt werden kann.");
+            return;
+        }
+
+        await RemoveGameStat(gameStat);
+    }
+
+    private async Task RemoveGameStat(GameStatDto gameStatDto)
+    {
+        var response = await HttpClient.DeleteAsync($"api/GameStat/DeleteGameStat/{gameStatDto.Id}");
+        var content = await response.Content.ReadFromJsonAsync<RpgStatsResponse<GameStatDto>>();
+        if (!response.IsSuccessStatusCode || content?.Success == false)
+        {
+            await ShowErrorMessage(content?.ErrorMessage ?? "Fehler beim Löschen des Status-Typs.");
+            return;
+        }
+
+        await GetGameStats();
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `RpgStats.BlazorServer/Pages/Games/GameDetail.razor` file, focusing on the addition of functionality to remove a `MudChip` and handle associated game statistics. The key changes include adding a new method to handle the removal of `MudChip`, updating the `MudChip` component to include an `OnClose` event, and adding a new method to remove game statistics.

### Functional Enhancements:

* Updated the `MudChip` component to include an `OnClose` event that triggers the `RemoveMudChip` method. (`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`)
* Added the `RemoveMudChip` method to handle the removal of a `MudChip`, which includes checking for associated game statistics and removing them if certain conditions are met. (`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`)
* Added the `RemoveGameStat` method to delete a game statistic from the server and refresh the game statistics list. (`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`)

### Code Quality Improvements:

* Added a blank line for better readability before navigating to the "/allGames" route. (`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`)