### PR TITLE
#62 bugfix all statvalues saveable

### DIFF
--- a/RpgStats.BlazorServer/Shared/StatValuesCreate.razor
+++ b/RpgStats.BlazorServer/Shared/StatValuesCreate.razor
@@ -81,11 +81,9 @@
             var response = await HttpClient.PostAsJsonAsync($"api/StatValue/CreateStatValue/{Character?.Id}/{statValueDto.StatId}", svCreationDto);
             var responseContent = await response.Content.ReadFromJsonAsync<RpgStatsResponse<StatValueDto>>();
 
-            if (response.IsSuccessStatusCode) return;
-            await ShowErrorMessage("Fehler beim Speichern der Werte.");
+            if (!response.IsSuccessStatusCode && responseContent?.Success == false)
+                await ShowErrorMessage("Fehler beim Speichern der Werte");
 
-            if (responseContent?.Success != false) continue;
-            await ShowErrorMessage(responseContent.ErrorMessage);
         }
         MudDialog?.Close(DialogResult.Ok(_statValues));
     }


### PR DESCRIPTION
This pull request includes a small but significant change to the `RpgStats.BlazorServer/Shared/StatValuesCreate.razor` file. The change improves error handling when saving stat values by checking both the HTTP response status and the success property of the response content.

Error handling improvement:

* Modified the error handling logic to check both the HTTP response status and the `Success` property of the response content before showing an error message. This ensures that the error message is only shown when the operation fails based on both conditions.