### PR TITLE
#69 load needed libs for skiasharp

### DIFF
--- a/RpgStats.BlazorServer/Dockerfile
+++ b/RpgStats.BlazorServer/Dockerfile
@@ -1,4 +1,10 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libfontconfig1 \
+        libfreetype6 \
+        libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8081
@@ -22,4 +28,6 @@ RUN dotnet publish "RpgStats.BlazorServer.csproj" -c $BUILD_CONFIGURATION -o /ap
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN mkdir -p /app/runtimes/linux-x64/native
+COPY --from=build /app/build/runtimes/linux-x64/native/libSkiaSharp.so /app/runtimes/linux-x64/native/
 ENTRYPOINT ["dotnet", "RpgStats.BlazorServer.dll"]

--- a/RpgStats.BlazorServer/Program.cs
+++ b/RpgStats.BlazorServer/Program.cs
@@ -2,7 +2,6 @@ using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// read appsettings for "api" section
 builder.Configuration.GetSection("Api").Bind(builder.Configuration);
 
 // Add services to the container.

--- a/RpgStats.BlazorServer/RpgStats.BlazorServer.csproj
+++ b/RpgStats.BlazorServer/RpgStats.BlazorServer.csproj
@@ -26,6 +26,7 @@
         <PackageReference Include="MudBlazor" Version="6.21.0"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="SkiaSharp" Version="2.88.8"/>
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.8" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.7.0"/>
     </ItemGroup>


### PR DESCRIPTION
This pull request includes several updates to the `RpgStats.BlazorServer` project, focusing on Dockerfile improvements, dependency updates, and configuration changes. The most important changes are listed below:

### Dockerfile Improvements:

* Added installation of necessary libraries (`libfontconfig1`, `libfreetype6`, `libicu-dev`) to the Dockerfile to support the application runtime.
* Added steps to copy `libSkiaSharp.so` to the appropriate directory in the Dockerfile to ensure SkiaSharp works correctly on Linux.

### Dependency Updates:

* Added `SkiaSharp.NativeAssets.Linux` package to the project file to support SkiaSharp on Linux environments.

### Configuration Changes:

* Removed a comment related to reading the appsettings "api" section in `Program.cs` for cleaner code.