### PR TITLE
fix: error in gamedetail when link gamestat with no stats in app

### DIFF
--- a/RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor
+++ b/RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor
@@ -43,8 +43,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var response = await HttpClient.GetFromJsonAsync<RpgStatsResponse<List<StatDto>>>("api/Stat/GetStats");
-        _stats = response?.Data;
+        await GetStats();
     }
 
     private void Cancel()
@@ -57,6 +56,21 @@
         if (Game != null) _gameStatDto.GameId = Game.Id;
         if (_stats != null) _gameStatDto.StatId = _stats.Single(x => x.ShortName == _stat).Id;
         await CreateGameStat();
+    }
+
+    private async Task GetStats()
+    {
+        var response = await HttpClient.GetAsync($"api/Stat/GetStats");
+        var content = await response.Content.ReadFromJsonAsync<RpgStatsResponse<List<StatDto>>>();
+        if (!response.IsSuccessStatusCode || content?.Success == false)
+        {
+            await ShowErrorMessage(content?.ErrorMessage ?? "Fehler beim Laden der Status-Typen.");
+            MudDialog?.Cancel();
+        }
+        else
+        {
+            _stats = content?.Data ?? new List<StatDto>();
+        }
     }
 
     private async Task CreateGameStat()


### PR DESCRIPTION
This pull request introduces a refactoring to the `RpgStats.BlazorServer/Shared/LinkGameStatDialog.razor` file, focusing on improving the method structure and error handling for fetching statistics.

Refactoring and improvements:

* Extracted the logic for fetching statistics into a new private method `GetStats` to improve code readability and reusability. [[1]](diffhunk://#diff-92b21c14029a498417c943dc69e565683cfd7643741ae6cb9e6fee741cb764e4L46-R46) [[2]](diffhunk://#diff-92b21c14029a498417c943dc69e565683cfd7643741ae6cb9e6fee741cb764e4R61-R75)
* Enhanced error handling in the `GetStats` method to display an error message and cancel the dialog if the API call fails or the response indicates a failure.