### PR TITLE
#74 gamedetail last chip will be removed too

### DIFF
--- a/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
+++ b/RpgStats.BlazorServer/Pages/Games/GameDetail.razor
@@ -171,12 +171,12 @@ else
     private async Task GetGameStats()
     {
         var response = await HttpClient.GetAsync($"api/GameStat/GetGameStatsByGame/{_game?.Id}");
-
         if (response.IsSuccessStatusCode == false)
+        {
+            _gameStats = new List<GameStatDto>();
             return;
-
+        }
         var rpgStatsResponse = await response.Content.ReadFromJsonAsync<RpgStatsResponse<List<GameStatDto>>>();
-
         _gameStats = rpgStatsResponse?.Data?.OrderBy(x => x.SortIndex).ToList();
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `RpgStats.BlazorServer/Pages/Games/GameDetail.razor` file. The change ensures that `_gameStats` is initialized to an empty list if the response is not successful.

* [`RpgStats.BlazorServer/Pages/Games/GameDetail.razor`](diffhunk://#diff-ee47b2403bdc0718ec9f6c4a4710773bfe474933e583160486970fa6491e133cL174-L179): Added initialization of `_gameStats` to an empty list if the response is not successful in the `GetGameStats` method.